### PR TITLE
Add a `watch` function

### DIFF
--- a/src/TailwindCSS.jl
+++ b/src/TailwindCSS.jl
@@ -5,9 +5,11 @@ using Artifacts
 export tailwindcss
 
 """
-    tailwindcss() -> Cmd
+    tailwindcss(; kws...) -> Cmd
 
 Return a `Cmd` object that can be used to run the `tailwindcss` executable.
+
+`kws` are passed to the `Cmd` as keywords.
 
 # Examples
 
@@ -16,9 +18,9 @@ julia> run(`$(tailwindcss()) --help`)
 
 ```
 """
-function tailwindcss()
+function tailwindcss(; kws...)
     path = joinpath(artifact"tailwindcss", "tailwindcss$(Sys.iswindows() ? ".exe" : "")")
-    return Cmd(Cmd([path]); env = copy(ENV)) # Somewhat replicating JLLWrapper behavior.
+    return Cmd(Cmd([path]); env = copy(ENV), kws...) # Somewhat replicating JLLWrapper behavior.
 end
 
 """
@@ -97,6 +99,111 @@ function build(;
                     @info "running tailwind build"
                     run(`$(bin) build --input $(input) --output $(output)`)
                     return nothing
+                else
+                    error("'$input' is not a file.")
+                end
+            end
+        else
+            error("Could not find 'tailwind.config.js' in '$root'.")
+        end
+    else
+        error("'$root' is not a directory.")
+    end
+end
+
+function default_on_change()
+    @debug "tailwind build finished"
+end
+
+# Wrapper for better printing and user interaction with the watcher object.
+struct Watcher
+    f::Function
+end
+
+function Base.show(io::IO, w::Watcher)
+    running = istaskstarted(w.f.task) && !istaskdone(w.f.task)
+    print(io, "$(Watcher)(running = $running)")
+end
+
+Base.close(w::Watcher) = w.f()
+
+"""
+    watch(;
+        root::AbstractString = pwd(),
+        input::AbstractString = "input.css",
+        output::AbstractString = joinpath("dist", "output.css"),
+        after_rebuild::Function,
+    ) -> Watcher
+
+Runs `tailwindcss build --watch` in the given `root` directory, watching the
+`input` file and writing to the `output` file in a similar fashion to the
+`build` function. `after_rebuild` is called whenever the build finishes.  This
+is a zero-argument function that can be used to run any code after the rebuild
+finishes, such as browser auto-reloaders.
+
+The returned `Watcher` object can be `close`d to stop the watcher.
+"""
+function watch(;
+    root::AbstractString = pwd(),
+    input::AbstractString = "input.css",
+    output::AbstractString = joinpath("dist", "output.css"),
+    after_rebuild::Function = default_on_change,
+)
+    if isdir(root)
+        config = joinpath(root, "tailwind.config.js")
+        if isfile(config)
+            cd(root) do
+                if isfile(input)
+                    if !isdir(dirname(output))
+                        @info "'$(dirname(output))' directory does not exist. Creating..."
+                        mkpath(dirname(output))
+                    end
+
+                    bin = tailwindcss(; dir = pwd())
+
+                    inp = Base.PipeEndpoint()
+                    out = Base.PipeEndpoint()
+                    err = Base.PipeEndpoint()
+
+                    process = run(
+                        `$(bin) build --watch --input $(input) --output $(output)`,
+                        inp,
+                        out,
+                        err;
+                        wait = false,
+                    )
+
+                    closed = Ref(false)
+                    task = @async begin
+                        @info "running tailwind watcher"
+                        while !closed[] && process_running(process)
+                            msg = strip(String(readavailable(err)))
+                            if !isempty(msg)
+                                if startswith(msg, "Done in ")
+                                    after_rebuild()
+                                elseif msg == "Rebuilding..."
+                                    @debug "$msg"
+                                else
+                                    printstyled("\n$msg\n"; color = :red)
+                                end
+                            end
+                        end
+                        @info "tailwind watcher exited"
+                    end
+
+                    return Watcher() do
+                        if closed[]
+                            error("tailwind watcher already closed.")
+                        else
+                            closed[] = true
+                            @info "closing tailwind watcher"
+                            process_running(process) || Base.close(process)
+                            Base.close(inp)
+                            Base.close(out)
+                            Base.close(err)
+                            return wait(task)
+                        end
+                    end
                 else
                     error("'$input' is not a file.")
                 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,6 +62,7 @@ using Test
             TailwindCSS.build(; input = "src/input.css")
 
             @test isfile("dist/output.css")
+            mtime_output = mtime("dist/output.css")
 
             # Check that the output css contains the expected class.
             let output_css = read("dist/output.css", String)
@@ -69,6 +70,50 @@ using Test
                 @test occursin("text-3xl", output_css)
                 @test occursin("font-bold", output_css)
                 @test occursin("underline", output_css)
+                @test !occursin("bg-blue-100", output_css)
+            end
+
+            has_run = Ref(0)
+            after_rebuild = function ()
+                has_run[] += 1
+            end
+            watcher = TailwindCSS.watch(; input = "src/input.css", after_rebuild)
+            sleep(5)
+            @test has_run[] == 1
+
+            # Update the test html file.
+            write(
+                "src/index.html",
+                """
+                <!doctype html>
+                <html>
+                <head>
+                  <meta charset="UTF-8">
+                  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                  <link href="/dist/output.css" rel="stylesheet">
+                </head>
+                <body>
+                  <h1 class="text-xl font-bold bg-blue-100">
+                    Hello world!
+                  </h1>
+                </body>
+                </html>
+                """,
+            )
+            sleep(1)
+            @test has_run[] == 2
+
+            close(watcher)
+
+            @test has_run[] == 2
+            @test mtime("dist/output.css") > mtime_output
+
+            # Check that the output css contains the expected class.
+            let output_css = read("dist/output.css", String)
+                @test occursin("--tw", output_css)
+                @test occursin("text-xl", output_css)
+                @test occursin("font-bold", output_css)
+                @test occursin("bg-blue-100", output_css)
             end
         end
     end


### PR DESCRIPTION
Wraps the `--watch`  flag that `tailwindcss` supports, but allows for setting
Julia callback function that is run each time a rebuild finishes. This is
useful for hooking into hot-reloading of a browser for automatically refreshing
on changes.